### PR TITLE
H2k type1 heating

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -35,3 +35,10 @@
 - Photovoltaics (Generation section)
 - Batteries (Battery specs not provided in h2k)
 - Generators (not explicit in h2k)
+
+
+### To-be addressed HVAC components (identified throughout translation)
+- Dual fuel system (bi-energy)
+- flue diameter inputs
+- distribution system selection
+- Combos (after heating and hot water complete)

--- a/docs/assumptions.md
+++ b/docs/assumptions.md
@@ -22,6 +22,10 @@
 - All "exterior use" consumption in HOT2000's baseloads are lumped under exterior lighting in HPXML.
 
 
+- Heating system types require efficiency to be defined in a specific way: Furnaces and boilers require AFUE, and Stoves and Fireplaces require Percents (Steady state in h2k). These efficiency input types are not interchangeable in HPXML, but are in H2k. This means that, if an h2k furnace has its efficiency defined in terms of steady state percent, that value will be interpreted by HPXML as an AFUE value. There doesn't appear to be a way around this without an explicit relationship between the two efficiency types.
+- Electric auxiliary energy (330 kWh/y for oil and 170 kWh/y for gas) overwritten with 0 kWh/year for boilers because no discernible difference in consumption is observed between homes with furnaces vs boilers in h2k. 
+
+
 ### Field Assumptions:
 - Building Site Type = suburban
 - Building Site Surroundings = stand-alone

--- a/h2ktohpxml/Model.py
+++ b/h2ktohpxml/Model.py
@@ -161,8 +161,7 @@ class ModelData:
         return self.is_dhw_translated
 
     def set_hvac_distribution_type(self, val):
-        if val in ["air", "hydronic"]:
-            self.hvac_distribution_type = val
+        self.hvac_distribution_type = val
 
     def get_hvac_distribution_type(self):
         return self.hvac_distribution_type

--- a/h2ktohpxml/Model.py
+++ b/h2ktohpxml/Model.py
@@ -21,6 +21,12 @@ class ModelData:
         self.crawlspace_count = 0
         self.slab_count = 0
 
+        # Tracking info for Systems
+        self.is_hvac_translated = False
+        self.is_dhw_translated = False
+        self.hvac_distribution_type = None
+        self.system_ids = {"primary_heating": "HeatingSystem1"}
+
         # Tracking errors
         self.error_list = []
 
@@ -139,3 +145,44 @@ class ModelData:
 
     def get_slab_count(self):
         return self.slab_count
+
+    def set_is_hvac_translated(self, val):
+        # Set to True if we've translated the entire HVAC system into a valid object
+        self.is_hvac_translated = val
+
+    def set_is_dhw_translated(self, val):
+        # Set to True if we've translated the entire DHW system into a valid object
+        self.is_dhw_translated = val
+
+    def get_is_hvac_translated(self):
+        return self.is_hvac_translated
+
+    def get_is_dhw_translated(self):
+        return self.is_dhw_translated
+
+    def set_hvac_distribution_type(self, val):
+        if val in ["air", "hydronic"]:
+            self.hvac_distribution_type = val
+
+    def get_hvac_distribution_type(self):
+        return self.hvac_distribution_type
+
+    # tracking hvac system ids
+
+    def __getid__(self, key):
+        return self.system_ids.get(key, key)
+
+    def __setid__(self, key, newvalue):
+        self.system_ids[key] = newvalue
+
+    def set_system_id(self, obj):
+        for key in obj.keys():
+            self.__setid__(key, obj[key])
+
+    def get_system_id(self, key, default=None):
+        value = self.__getid__(key)
+
+        if value == key:
+            return default
+        else:
+            return value

--- a/h2ktohpxml/config/numeric.json
+++ b/h2ktohpxml/config/numeric.json
@@ -30,30 +30,6 @@
             "hpxml": "HPXML,Building,BuildingDetails,BuildingSummary,BuildingConstruction,ConditionedFloorArea"
         }
     },
-    "baseboard_capacity": {
-        "units": {
-            "unit_type": "power",
-            "h2k_units": "kW",
-            "hpxml_units": "BTU/h"
-        },
-        "decimals": 2,
-        "address": {
-            "h2k": "Specifications,OutputCapacity,@value",
-            "hpxml": "HPXML,Building,BuildingDetails,Systems,HVAC,HVACPlant,HeatingSystem,HeatingCapacity"
-        }
-    },
-    "baseboard_efficiency": {
-        "units": {
-            "unit_type": "fraction",
-            "h2k_units": "%",
-            "hpxml_units": "fraction"
-        },
-        "decimals": 2,
-        "address": {
-            "h2k": "Specifications,@efficiency",
-            "hpxml": "HPXML,Building,BuildingDetails,Systems,HVAC,HVACPlant,HeatingSystem,AnnualHeatingEfficiency,Value"
-        }
-    },
     "bg_heated_floor_area":{
         "units": {
             "unit_type": "area",
@@ -521,6 +497,73 @@
         "address": {
             "h2k": "HouseFile,House,Ventilation,SupplementalVentilatorList,Dryer,@exhaustFlowrate",
             "hpxml": "HPXML,Building,BuildingDetails,Appliances,ClothesDryer,VentedFlowRate"
+        }
+    },
+    "baseboard_capacity": {
+        "units": {
+            "unit_type": "power",
+            "h2k_units": "kW",
+            "hpxml_units": "BTU/h"
+        },
+        "decimals": 2,
+        "address": {
+            "h2k": "Specifications,OutputCapacity,@value",
+            "hpxml": "HPXML,Building,BuildingDetails,Systems,HVAC,HVACPlant,HeatingSystem,HeatingCapacity"
+        }
+    },
+    "baseboard_efficiency": {
+        "units": {
+            "unit_type": "fraction",
+            "h2k_units": "%",
+            "hpxml_units": "fraction"
+        },
+        "decimals": 2,
+        "address": {
+            "h2k": "Specifications,@efficiency",
+            "hpxml": "HPXML,Building,BuildingDetails,Systems,HVAC,HVACPlant,HeatingSystem,AnnualHeatingEfficiency,Value"
+        }
+    },
+    "furnace_capacity": {
+        "units": {
+            "unit_type": "power",
+            "h2k_units": "kW",
+            "hpxml_units": "BTU/h"
+        },
+        "decimals": 2,
+        "address": {
+            "h2k": "Specifications,OutputCapacity,@value",
+            "hpxml": "HPXML,Building,BuildingDetails,Systems,HVAC,HVACPlant,HeatingSystem,HeatingCapacity"
+        }
+    },
+    "furnace_sizing_factor": {
+        "decimals": 2,
+        "address": {
+            "h2k": "Specifications,@sizingFactor",
+            "hpxml": "HPXML,Building,BuildingDetails,Systems,HVAC,HVACPlant,HeatingSystem,extension,HeatingAutosizingFactor"
+        }
+    },
+    "furnace_efficiency": {
+        "units": {
+            "unit_type": "fraction",
+            "h2k_units": "%",
+            "hpxml_units": "fraction"
+        },
+        "decimals": 2,
+        "address": {
+            "h2k": "Specifications,@efficiency",
+            "hpxml": "HPXML,Building,BuildingDetails,Systems,HVAC,HVACPlant,HeatingSystem,AnnualHeatingEfficiency,Value"
+        }
+    },
+    "furnace_pilot_light": {
+        "units": {
+            "unit_type": "daily_energy",
+            "h2k_units": "MJ/day",
+            "hpxml_units": "BTU/h"
+        },
+        "decimals": 2,
+        "address": {
+            "h2k": "Specifications,@pilotLight",
+            "hpxml": "HPXML,Building,BuildingDetails,Systems,HVAC,HVACPlant,HeatingSystem,Furnace,extension,PilotLightBtuh"
         }
     },
     "setpoint_heating_day": {

--- a/h2ktohpxml/config/numeric.json
+++ b/h2ktohpxml/config/numeric.json
@@ -30,6 +30,30 @@
             "hpxml": "HPXML,Building,BuildingDetails,BuildingSummary,BuildingConstruction,ConditionedFloorArea"
         }
     },
+    "baseboard_capacity": {
+        "units": {
+            "unit_type": "power",
+            "h2k_units": "kW",
+            "hpxml_units": "BTU/h"
+        },
+        "decimals": 2,
+        "address": {
+            "h2k": "Specifications,OutputCapacity,@value",
+            "hpxml": "HPXML,Building,BuildingDetails,Systems,HVAC,HVACPlant,HeatingSystem,HeatingCapacity"
+        }
+    },
+    "baseboard_efficiency": {
+        "units": {
+            "unit_type": "fraction",
+            "h2k_units": "%",
+            "hpxml_units": "fraction"
+        },
+        "decimals": 2,
+        "address": {
+            "h2k": "Specifications,@efficiency",
+            "hpxml": "HPXML,Building,BuildingDetails,Systems,HVAC,HVACPlant,HeatingSystem,AnnualHeatingEfficiency,Value"
+        }
+    },
     "bg_heated_floor_area":{
         "units": {
             "unit_type": "area",
@@ -497,6 +521,49 @@
         "address": {
             "h2k": "HouseFile,House,Ventilation,SupplementalVentilatorList,Dryer,@exhaustFlowrate",
             "hpxml": "HPXML,Building,BuildingDetails,Appliances,ClothesDryer,VentedFlowRate"
+        }
+    },
+    "setpoint_heating_day": {
+        "units": {
+            "unit_type": "temperature",
+            "h2k_units": "C",
+            "hpxml_units": "F"
+        },
+        "decimals": 2,
+        "address": {
+            "h2k": "HouseFile,House,Temperatures,MainFloors,@daytimeHeatingSetPoint",
+            "hpxml": "HPXML,Building,BuildingDetails,Systems,HVAC,HVACControl,SetpointTempHeatingSeason"
+        }
+    },
+    "setpoint_cooling_day": {
+        "units": {
+            "unit_type": "temperature",
+            "h2k_units": "C",
+            "hpxml_units": "F"
+        },
+        "decimals": 2,
+        "address": {
+            "h2k": "HouseFile,House,Temperatures,MainFloors,@coolingSetPoint",
+            "hpxml": "HPXML,Building,BuildingDetails,Systems,HVAC,HVACControl,SetpointTempCoolingSeason"
+        }
+    },
+    "setpoint_heating_night": {
+        "units": {
+            "unit_type": "temperature",
+            "h2k_units": "C",
+            "hpxml_units": "F"
+        },
+        "decimals": 2,
+        "address": {
+            "h2k": "HouseFile,House,Temperatures,MainFloors,@nighttimeHeatingSetPoint",
+            "hpxml": "HPXML,Building,BuildingDetails,Systems,HVAC,HVACControl,SetbackTempHeatingSeason"
+        }
+    },
+    "setback_heating_duration": {
+        "decimals": 0,
+        "address": {
+            "h2k": "HouseFile,House,Temperatures,MainFloors,@nighttimeSetbackDuration",
+            "hpxml": "HPXML,Building,BuildingDetails,Systems,HVAC,HVACControl,TotalSetbackHoursperWeekHeating"
         }
     }
 }

--- a/h2ktohpxml/config/selection.json
+++ b/h2ktohpxml/config/selection.json
@@ -324,5 +324,39 @@
             "other"
         ],
         "default": "air"
+    },
+    "furnace_fuel_type": {
+        "address": {
+            "h2k": "Equipment,EnergySource,English",
+            "hpxml": "HPXML,Building,BuildingDetails,Systems,HVAC,HVACPlant,HeatingSystem,HeatingSystemFuel"
+        },
+        "map": {
+            "Electric": "electricity",
+            "Natural gas": "natural gas",
+            "Oil": "fuel oil",
+            "Propane": "propane",
+            "Mixed Wood": "wood",
+            "Hardwood": "wood",
+            "Softwood": "wood",
+            "Wood Pellets": "wood pellets"
+        },
+        "hpxml_opts": [
+            "electricity", 
+            "natural gas", 
+            "fuel oil", 
+            "fuel oil 1", 
+            "fuel oil 2", 
+            "fuel oil 4", 
+            "fuel oil 5/6", 
+            "diesel", 
+            "propane", 
+            "kerosene", 
+            "coal", 
+            "coke", 
+            "bituminous coal", 
+            "wood", 
+            "wood pellets"
+        ],
+        "default": "electricity"
     }
 }

--- a/h2ktohpxml/h2ktohpxml.py
+++ b/h2ktohpxml/h2ktohpxml.py
@@ -329,7 +329,7 @@ def h2ktohpxml(h2k_string="", config={}):
         # Add warning/error
         model_data.add_warning_message(
             {
-                "message": "The h2k file contains an HVAC system that is not supported by the translation. The default HVAC section from the template was used in the output HPXML file."
+                "message": "The h2k file contains an HVAC system that is not supported by the translation process. The default HVAC section from the template was used in the output HPXML file."
             }
         )
 

--- a/h2ktohpxml/h2ktohpxml.py
+++ b/h2ktohpxml/h2ktohpxml.py
@@ -321,7 +321,7 @@ def h2ktohpxml(h2k_string="", config={}):
     # dhw_dict = systems_results["dhw_dict"]
 
     # only update the heating system from the template if we've translated the h2k into a valid object
-    if model_data.get_is_hvac_translated:
+    if model_data.get_is_hvac_translated():
         hpxml_dict["HPXML"]["Building"]["BuildingDetails"]["Systems"][
             "HVAC"
         ] = hvac_dict

--- a/h2ktohpxml/systems/hvac_control.py
+++ b/h2ktohpxml/systems/hvac_control.py
@@ -1,0 +1,50 @@
+import math
+
+from ..utils import obj, h2k
+
+
+# Returns the HVAC Control system dictionary
+# Essentially contains the "Temperatures" section of h2k
+def get_hvac_control(h2k_dict, model_data):
+
+    setpoint_heating_day = h2k.get_number_field(h2k_dict, "setpoint_heating_day")
+    setpoint_cooling_day = h2k.get_number_field(h2k_dict, "setpoint_cooling_day")
+    setpoint_heating_night = h2k.get_number_field(h2k_dict, "setpoint_heating_night")
+    setback_heating_duration = h2k.get_number_field(
+        h2k_dict, "setback_heating_duration"
+    )
+
+    # Note
+    # Setbacks are always present in h2k
+    # setback start hours can be defined in extension/SetbackStartHourHeating, but the default is the same as h2k (11pm)
+    # TODO: convert simple set back inputs to hourly arrays if h2k doesn't do setbacks on weekends
+    hvac_control_dict = {
+        "SystemIdentifier": {"@id": "HVACControl1"},
+        "SetpointTempHeatingSeason": setpoint_heating_day,
+        "SetbackTempHeatingSeason": setpoint_heating_night,
+        "TotalSetbackHoursperWeekHeating": setback_heating_duration * 7,
+        "SetpointTempCoolingSeason": setpoint_cooling_day,
+    }
+
+    return hvac_control_dict
+
+
+# Element Order:
+# SystemInfo
+# ConnectedDevice
+# AttachedToZone
+# ControlType
+# SetpointTempHeatingSeason
+# SetbackTempHeatingSeason
+# TotalSetbackHoursperWeekHeating
+# SetupTempCoolingSeason
+# SetpointTempCoolingSeason
+# TotalSetupHoursperWeekCooling
+# HotWaterResetControl
+# HeatLowered
+# ACAdjusted
+# FractionThermostaticRadiatorValves
+# FractionElectronicZoneValves
+# HVACSystemsServed
+# HeatingSeason
+# CoolingSeason

--- a/h2ktohpxml/systems/hvac_distribution.py
+++ b/h2ktohpxml/systems/hvac_distribution.py
@@ -38,7 +38,7 @@ def get_hvac_distribution(h2k_dict, model_data):
                             "DuctType": "supply",
                             "DuctLeakage": {
                                 "Units": "CFM25",
-                                "Value": 75.0,
+                                "Value": 0,
                                 "TotalOrToOutside": "to outside",
                             },
                         },
@@ -46,7 +46,7 @@ def get_hvac_distribution(h2k_dict, model_data):
                             "DuctType": "return",
                             "DuctLeakage": {
                                 "Units": "CFM25",
-                                "Value": 25.0,
+                                "Value": 0,
                                 "TotalOrToOutside": "to outside",
                             },
                         },

--- a/h2ktohpxml/systems/hvac_distribution.py
+++ b/h2ktohpxml/systems/hvac_distribution.py
@@ -1,0 +1,27 @@
+import math
+
+from ..utils import obj, h2k
+
+
+# Returns the HVAC distribution system based on the specified type
+# "air"
+# "hydronic"
+# Distribution System Efficiency (DSE) is NOT SUPPORTED (no h2k representation)
+def get_hvac_distribution(h2k_dict, model_data):
+
+    hvac_dist_type = model_data.get_hvac_distribution_type()
+    primary_heating_id = model_data.get_system_id("primary_heating")
+    air_conditioner_id = model_data.get_system_id("air_conditioner")
+    air_heat_pump_id = model_data.get_system_id("air_heat_pump")
+    ground_heat_pump_id = model_data.get_system_id("ground_heat_pump")
+    water_heat_pump_id = model_data.get_system_id("water_heat_pump")
+
+    hvac_dist_dict = {}
+
+    if hvac_dist_type == "air":
+        pass
+
+    elif hvac_dist_type == "hydronic":
+        pass
+
+    return hvac_dist_dict

--- a/h2ktohpxml/systems/hvac_distribution.py
+++ b/h2ktohpxml/systems/hvac_distribution.py
@@ -22,7 +22,6 @@ def get_hvac_distribution(h2k_dict, model_data):
 
     hvac_dist_dict = {}
 
-    print("hvac_dist_type", hvac_dist_type)
     if "air_" in str(hvac_dist_type):
         # “regular velocity”, “gravity”, or “fan coil” are the supported types
         # Not all of these are defined in h2k
@@ -70,8 +69,18 @@ def get_hvac_distribution(h2k_dict, model_data):
 
     elif "hydronic_" in str(hvac_dist_type):
         # HydronicDistributionType choices are “radiator”, “baseboard”, “radiant floor”, “radiant ceiling”, or “water loop”.
-        # However, h2k does not include sufficient information to determine which is used, so we default to "radiant floor"
+        # However, h2k does not include sufficient information to determine which is used, so we default to "radiator" (without radiant floor explicitly defined)
 
-        pass
+        [base_type, sub_type] = hvac_dist_type.split("_")
+        # Currently only handling regular velocity with default duct inputs
+        hvac_dist_dict = {
+            "SystemIdentifier": {"@id": model_data.get_system_id("hvac_distribution")},
+            "DistributionSystemType": {
+                "HydronicDistribution": {
+                    "HydronicDistributionType": sub_type,
+                }
+            },
+            "ConditionedFloorAreaServed": ag_heated_floor_area + bg_heated_floor_area,
+        }
 
     return hvac_dist_dict

--- a/h2ktohpxml/systems/hvac_distribution.py
+++ b/h2ktohpxml/systems/hvac_distribution.py
@@ -16,12 +16,62 @@ def get_hvac_distribution(h2k_dict, model_data):
     ground_heat_pump_id = model_data.get_system_id("ground_heat_pump")
     water_heat_pump_id = model_data.get_system_id("water_heat_pump")
 
+    # TODO: Better handle determination of which floor areas to include here (total area assumed)
+    ag_heated_floor_area = model_data.get_building_detail("ag_heated_floor_area")
+    bg_heated_floor_area = model_data.get_building_detail("bg_heated_floor_area")
+
     hvac_dist_dict = {}
 
-    if hvac_dist_type == "air":
-        pass
+    print("hvac_dist_type", hvac_dist_type)
+    if "air_" in str(hvac_dist_type):
+        # “regular velocity”, “gravity”, or “fan coil” are the supported types
+        # Not all of these are defined in h2k
+        [base_type, sub_type] = hvac_dist_type.split("_")
+        # Currently only handling regular velocity with default duct inputs
+        hvac_dist_dict = {
+            "SystemIdentifier": {"@id": model_data.get_system_id("hvac_distribution")},
+            "DistributionSystemType": {
+                "AirDistribution": {
+                    "AirDistributionType": sub_type,
+                    "DuctLeakageMeasurement": [
+                        {
+                            "DuctType": "supply",
+                            "DuctLeakage": {
+                                "Units": "CFM25",
+                                "Value": 75.0,
+                                "TotalOrToOutside": "to outside",
+                            },
+                        },
+                        {
+                            "DuctType": "return",
+                            "DuctLeakage": {
+                                "Units": "CFM25",
+                                "Value": 25.0,
+                                "TotalOrToOutside": "to outside",
+                            },
+                        },
+                    ],
+                    "Ducts": [
+                        {
+                            "SystemIdentifier": {"@id": "Ducts1"},
+                            "DuctType": "supply",
+                            "DuctInsulationRValue": 0.0,
+                        },
+                        {
+                            "SystemIdentifier": {"@id": "Ducts2"},
+                            "DuctType": "return",
+                            "DuctInsulationRValue": 0.0,
+                        },
+                    ],
+                }
+            },
+            "ConditionedFloorAreaServed": ag_heated_floor_area + bg_heated_floor_area,
+        }
 
-    elif hvac_dist_type == "hydronic":
+    elif "hydronic_" in str(hvac_dist_type):
+        # HydronicDistributionType choices are “radiator”, “baseboard”, “radiant floor”, “radiant ceiling”, or “water loop”.
+        # However, h2k does not include sufficient information to determine which is used, so we default to "radiant floor"
+
         pass
 
     return hvac_dist_dict

--- a/h2ktohpxml/systems/primary_heating.py
+++ b/h2ktohpxml/systems/primary_heating.py
@@ -1,0 +1,59 @@
+import math
+
+from ..utils import obj, h2k
+
+
+# Translates data from the "Type1" heating system section of h2k
+def get_primary_heating_system(h2k_dict, model_data):
+
+    type1_heating_system = obj.get_val(h2k_dict, "HouseFile,House,HeatingCooling,Type1")
+
+    # h2k files cannot be built without a Type 1 heating system, so we don't need to check for the presence of one
+    type1_type = [x for x in list(type1_heating_system.keys()) if x != "FansAndPump"][0]
+
+    type1_data = type1_heating_system.get(type1_type, {})
+
+    print("type1 system type", type1_type)
+
+    # Only one primary heating system, define its id
+    model_data.set_system_id({"primary_heating": "HeatingSystem1"})
+
+    primary_heating_dict = {}
+    if type1_type == "Baseboards":
+        # TODO: Remove after testing
+        model_data.set_is_hvac_translated(True)
+        primary_heating_dict = get_electric_resistance(
+            type1_data, model_data.get_system_id("primary_heating")
+        )
+
+    return primary_heating_dict
+
+
+# Translates h2k's Baseboards Type1 system
+def get_electric_resistance(type1_data, primary_heating_id):
+
+    baseboard_capacity = h2k.get_number_field(type1_data, "baseboard_capacity")
+    baseboard_efficiency = h2k.get_number_field(type1_data, "baseboard_efficiency")
+
+    # By default we assume electric resistance, overwriting with radiant if present
+    # “baseboard”, “radiant floor”, or “radiant ceiling”
+    elec_resistance = {
+        "SystemIdentifier": {"@id": primary_heating_id},
+        "HeatingSystemType": {
+            "ElectricResistance": {"ElectricDistribution": "baseboard"}
+        },
+        "HeatingSystemFuel": "electricity",
+        "HeatingCapacity": baseboard_capacity,
+        "AnnualHeatingEfficiency": {
+            "Units": "Percent",  # Only unit type allowed here. Note actual value must be a fraction
+            "Value": baseboard_efficiency,
+        },
+        "FractionHeatLoadServed": 1,  # Hardcoded for now
+    }
+
+    print(elec_resistance)
+
+    # TODO: FractionHeatLoadServed is not allowed if this is a heat pump backup system
+    # Also must sum to 1 across all heating systems
+
+    return elec_resistance

--- a/h2ktohpxml/systems/primary_heating.py
+++ b/h2ktohpxml/systems/primary_heating.py
@@ -2,6 +2,20 @@ import math
 
 from ..utils import obj, h2k
 
+# Handled here, not in selection.json, because the format is slightly different
+fireplace_stove_equip_map = {
+    "advanced airtight wood stove": "stove",
+    "1st option with catalytic converter": "stove",
+    "conventional furnace": None,
+    "conventional stove": "stove",
+    "pellet stove": "stove",
+    "masonry heater": None,
+    "conventional fireplace": "fireplace",
+    "fireplace insert": "fireplace",
+}
+
+# TODO: Flue diameter not handled
+
 
 # Translates data from the "Type1" heating system section of h2k
 def get_primary_heating_system(h2k_dict, model_data):
@@ -22,8 +36,38 @@ def get_primary_heating_system(h2k_dict, model_data):
         primary_heating_dict = get_electric_resistance(type1_data, model_data)
 
     elif type1_type == "Furnace":
-        # model_data.set_is_hvac_translated(True)
-        primary_heating_dict = get_furnace(type1_data, model_data)
+        # TODO: Remove is_hvac_translated flag after testing
+        model_data.set_is_hvac_translated(True)
+
+        furnace_subtype = (
+            str(obj.get_val(type1_data, "Equipment,EquipmentType,English"))
+        ).lower()
+        print("furnace_subtype", furnace_subtype)
+
+        hpxml_heating_type = fireplace_stove_equip_map.get(furnace_subtype, None)
+        print("hpxml_heating_type", hpxml_heating_type)
+
+        if hpxml_heating_type == "stove":
+            # ignores differences between furnaces and boilers because HPXML has an explicit stove component
+            primary_heating_dict = get_stove(type1_data, model_data)
+        elif hpxml_heating_type == "fireplace":
+            # ignores differences between furnaces and boilers because HPXML has an explicit fireplace component
+            primary_heating_dict = get_fireplace(type1_data, model_data)
+        else:
+            primary_heating_dict = get_furnace(type1_data, model_data)
+
+    elif type1_type == "Boiler":
+        # TODO: Remove is_hvac_translated flag after testing
+        model_data.set_is_hvac_translated(True)
+
+        boiler_subtype = (
+            str(obj.get_val(type1_data, "Equipment,EquipmentType,English"))
+        ).lower()
+        print("boiler_subtype", boiler_subtype)
+
+        hpxml_heating_type = fireplace_stove_equip_map.get(boiler_subtype, None)
+
+        primary_heating_dict = get_boiler(type1_data, model_data)
 
     return primary_heating_dict
 
@@ -121,3 +165,157 @@ def get_furnace(type1_data, model_data):
     model_data.set_hvac_distribution_type("air_regular velocity")
 
     return furnace_dict
+
+
+def get_boiler(type1_data, model_data):
+    # Currently, this portion of the HPXML doesn't have an analog for the "Equipment type" field
+
+    boiler_capacity = h2k.get_number_field(type1_data, "furnace_capacity")
+
+    boiler_efficiency = h2k.get_number_field(type1_data, "furnace_efficiency")
+
+    # TODO: The documentation makes it look like the Units can be set to "Percent", but this throws an error when simulating
+    # Currently hardcoded to AFUE
+    is_steady_state = obj.get_val(type1_data, "Specifications,@isSteadyState")
+
+    boiler_sizing_factor = h2k.get_number_field(type1_data, "furnace_sizing_factor")
+    is_auto_sized = (
+        "Calculated" == obj.get_val(type1_data, "Specifications,OutputCapacity,English")
+        or boiler_capacity == 0
+    )
+
+    boiler_pilot_light = h2k.get_number_field(type1_data, "furnace_pilot_light")
+
+    boiler_fuel_type = h2k.get_selection_field(type1_data, "furnace_fuel_type")
+
+    # TODO: confirm desired behaviour around auto-sizing
+    boiler_dict = {
+        "SystemIdentifier": {"@id": model_data.get_system_id("primary_heating")},
+        "DistributionSystem": {"@idref": model_data.get_system_id("hvac_distribution")},
+        "HeatingSystemType": {
+            "Boiler": None
+        },  # potential to add pilot light info later
+        "HeatingSystemFuel": boiler_fuel_type,
+        **({} if is_auto_sized else {"HeatingCapacity": boiler_capacity}),
+        "AnnualHeatingEfficiency": {
+            "Units": (
+                "AFUE"  # "Percent" if is_steady_state == "true" else "AFUE"
+            ),  # "AFUE" / "Percent"
+            "Value": boiler_efficiency,
+        },
+        "FractionHeatLoadServed": 1,
+        "ElectricAuxiliaryEnergy": 0,  # Without this, HPXML assumes 330 kWh/y for oil and 170 kWh/y for gas boilers
+        **(
+            {"extension": {"HeatingAutosizingFactor": boiler_sizing_factor}}
+            if is_auto_sized
+            else {}
+        ),
+    }
+
+    # TODO: FractionHeatLoadServed is not allowed if this is a heat pump backup system
+    # Also must sum to 1 across all heating systems
+
+    # Add pilot light if present
+    if boiler_pilot_light > 0:
+        boiler_dict["HeatingSystemType"] = {
+            "Boiler": {
+                "PilotLight": "true",
+                "extension": {"PilotLightBtuh": boiler_pilot_light},
+            }
+        }
+
+    print("BOILER: ", boiler_dict)
+
+    # No h2k representation for "gravity" distribution type
+    # Might need to update this based on logic around system types
+    # TODO: change distribution type to "radiant floor" if in-floor is defined
+    # Option to use air_fan coil if boiler has a shared water loop with a heat pump
+    model_data.set_hvac_distribution_type("hydronic_radiator")
+
+    return boiler_dict
+
+
+def get_fireplace(type1_data, model_data):
+    # Furnace field keys still work here because the structure is either a furnace or boiler
+    fireplace_capacity = h2k.get_number_field(type1_data, "furnace_capacity")
+    fireplace_efficiency = h2k.get_number_field(type1_data, "furnace_efficiency")
+
+    # Fireplace accepts Percent, not AFUE
+    is_steady_state = obj.get_val(type1_data, "Specifications,@isSteadyState")
+
+    fireplace_sizing_factor = h2k.get_number_field(type1_data, "furnace_sizing_factor")
+    is_auto_sized = (
+        "Calculated" == obj.get_val(type1_data, "Specifications,OutputCapacity,English")
+        or fireplace_capacity == 0
+    )
+
+    fireplace_fuel_type = h2k.get_selection_field(type1_data, "furnace_fuel_type")
+
+    # TODO: confirm desired behaviour around auto-sizing
+    fireplace_dict = {
+        "SystemIdentifier": {"@id": model_data.get_system_id("primary_heating")},
+        "HeatingSystemType": {
+            "Fireplace": None
+        },  # potential to add pilot light info later
+        "HeatingSystemFuel": fireplace_fuel_type,
+        **({} if is_auto_sized else {"HeatingCapacity": fireplace_capacity}),
+        "AnnualHeatingEfficiency": {
+            "Units": "Percent",  # "AFUE" / "Percent"
+            "Value": fireplace_efficiency,
+        },
+        "FractionHeatLoadServed": 1,
+        **(
+            {"extension": {"HeatingAutosizingFactor": fireplace_sizing_factor}}
+            if is_auto_sized
+            else {}
+        ),
+    }
+
+    # TODO: FractionHeatLoadServed is not allowed if this is a heat pump backup system
+    # Also must sum to 1 across all heating systems
+
+    print("FURNACE (FIREPLACE): ", fireplace_dict)
+
+    return fireplace_dict
+
+
+def get_stove(type1_data, model_data):
+    # Furnace field keys still work here because the structure is either a furnace or boiler
+    stove_capacity = h2k.get_number_field(type1_data, "furnace_capacity")
+    stove_efficiency = h2k.get_number_field(type1_data, "furnace_efficiency")
+
+    # Stove accepts Percent, not AFUE
+    is_steady_state = obj.get_val(type1_data, "Specifications,@isSteadyState")
+
+    stove_sizing_factor = h2k.get_number_field(type1_data, "furnace_sizing_factor")
+    is_auto_sized = (
+        "Calculated" == obj.get_val(type1_data, "Specifications,OutputCapacity,English")
+        or stove_capacity == 0
+    )
+
+    stove_fuel_type = h2k.get_selection_field(type1_data, "furnace_fuel_type")
+
+    # TODO: confirm desired behaviour around auto-sizing
+    stove_dict = {
+        "SystemIdentifier": {"@id": model_data.get_system_id("primary_heating")},
+        "HeatingSystemType": {"Stove": None},  # potential to add pilot light info later
+        "HeatingSystemFuel": stove_fuel_type,
+        **({} if is_auto_sized else {"HeatingCapacity": stove_capacity}),
+        "AnnualHeatingEfficiency": {
+            "Units": "Percent",
+            "Value": stove_efficiency,
+        },
+        "FractionHeatLoadServed": 1,
+        **(
+            {"extension": {"HeatingAutosizingFactor": stove_sizing_factor}}
+            if is_auto_sized
+            else {}
+        ),
+    }
+
+    # TODO: FractionHeatLoadServed is not allowed if this is a heat pump backup system
+    # Also must sum to 1 across all heating systems
+
+    print("FURNACE (STOVE): ", stove_dict)
+
+    return stove_dict

--- a/h2ktohpxml/systems/primary_heating.py
+++ b/h2ktohpxml/systems/primary_heating.py
@@ -27,8 +27,6 @@ def get_primary_heating_system(h2k_dict, model_data):
 
     type1_data = type1_heating_system.get(type1_type, {})
 
-    print("type1 system type", type1_type)
-
     primary_heating_dict = {}
     if type1_type == "Baseboards":
         # TODO: Remove is_hvac_translated flag after testing
@@ -42,10 +40,8 @@ def get_primary_heating_system(h2k_dict, model_data):
         furnace_subtype = (
             str(obj.get_val(type1_data, "Equipment,EquipmentType,English"))
         ).lower()
-        print("furnace_subtype", furnace_subtype)
 
         hpxml_heating_type = fireplace_stove_equip_map.get(furnace_subtype, None)
-        print("hpxml_heating_type", hpxml_heating_type)
 
         if hpxml_heating_type == "stove":
             # ignores differences between furnaces and boilers because HPXML has an explicit stove component
@@ -60,13 +56,7 @@ def get_primary_heating_system(h2k_dict, model_data):
         # TODO: Remove is_hvac_translated flag after testing
         model_data.set_is_hvac_translated(True)
 
-        boiler_subtype = (
-            str(obj.get_val(type1_data, "Equipment,EquipmentType,English"))
-        ).lower()
-        print("boiler_subtype", boiler_subtype)
-
-        hpxml_heating_type = fireplace_stove_equip_map.get(boiler_subtype, None)
-
+        # Wood boilers not broken down into stoves and fireplaces, only indoor/outdoor
         primary_heating_dict = get_boiler(type1_data, model_data)
 
     return primary_heating_dict
@@ -93,8 +83,6 @@ def get_electric_resistance(type1_data, model_data):
         },
         "FractionHeatLoadServed": 1,  # Hardcoded for now
     }
-
-    print("BASEBOARD: ", elec_resistance)
 
     # TODO: FractionHeatLoadServed is not allowed if this is a heat pump backup system
     # Also must sum to 1 across all heating systems
@@ -157,8 +145,6 @@ def get_furnace(type1_data, model_data):
                 "extension": {"PilotLightBtuh": furnace_pilot_light},
             }
         }
-
-    print("FURNACE: ", furnace_dict)
 
     # No h2k representation for "gravity" distribution type
     # Might need to update this based on logic around system types
@@ -224,8 +210,6 @@ def get_boiler(type1_data, model_data):
             }
         }
 
-    print("BOILER: ", boiler_dict)
-
     # No h2k representation for "gravity" distribution type
     # Might need to update this based on logic around system types
     # TODO: change distribution type to "radiant floor" if in-floor is defined
@@ -274,8 +258,6 @@ def get_fireplace(type1_data, model_data):
     # TODO: FractionHeatLoadServed is not allowed if this is a heat pump backup system
     # Also must sum to 1 across all heating systems
 
-    print("FURNACE (FIREPLACE): ", fireplace_dict)
-
     return fireplace_dict
 
 
@@ -315,7 +297,5 @@ def get_stove(type1_data, model_data):
 
     # TODO: FractionHeatLoadServed is not allowed if this is a heat pump backup system
     # Also must sum to 1 across all heating systems
-
-    print("FURNACE (STOVE): ", stove_dict)
 
     return stove_dict

--- a/h2ktohpxml/systems/primary_heating.py
+++ b/h2ktohpxml/systems/primary_heating.py
@@ -15,22 +15,21 @@ def get_primary_heating_system(h2k_dict, model_data):
 
     print("type1 system type", type1_type)
 
-    # Only one primary heating system, define its id
-    model_data.set_system_id({"primary_heating": "HeatingSystem1"})
-
     primary_heating_dict = {}
     if type1_type == "Baseboards":
-        # TODO: Remove after testing
+        # TODO: Remove is_hvac_translated flag after testing
         model_data.set_is_hvac_translated(True)
-        primary_heating_dict = get_electric_resistance(
-            type1_data, model_data.get_system_id("primary_heating")
-        )
+        primary_heating_dict = get_electric_resistance(type1_data, model_data)
+
+    elif type1_type == "Furnace":
+        # model_data.set_is_hvac_translated(True)
+        primary_heating_dict = get_furnace(type1_data, model_data)
 
     return primary_heating_dict
 
 
 # Translates h2k's Baseboards Type1 system
-def get_electric_resistance(type1_data, primary_heating_id):
+def get_electric_resistance(type1_data, model_data):
 
     baseboard_capacity = h2k.get_number_field(type1_data, "baseboard_capacity")
     baseboard_efficiency = h2k.get_number_field(type1_data, "baseboard_efficiency")
@@ -38,7 +37,7 @@ def get_electric_resistance(type1_data, primary_heating_id):
     # By default we assume electric resistance, overwriting with radiant if present
     # “baseboard”, “radiant floor”, or “radiant ceiling”
     elec_resistance = {
-        "SystemIdentifier": {"@id": primary_heating_id},
+        "SystemIdentifier": {"@id": model_data.get_system_id("primary_heating")},
         "HeatingSystemType": {
             "ElectricResistance": {"ElectricDistribution": "baseboard"}
         },
@@ -51,9 +50,74 @@ def get_electric_resistance(type1_data, primary_heating_id):
         "FractionHeatLoadServed": 1,  # Hardcoded for now
     }
 
-    print(elec_resistance)
+    print("BASEBOARD: ", elec_resistance)
 
     # TODO: FractionHeatLoadServed is not allowed if this is a heat pump backup system
     # Also must sum to 1 across all heating systems
 
     return elec_resistance
+
+
+def get_furnace(type1_data, model_data):
+    # Currently, this portion of the HPXML doesn't have an analog for the "Equipment type" field
+
+    furnace_capacity = h2k.get_number_field(type1_data, "furnace_capacity")
+
+    furnace_efficiency = h2k.get_number_field(type1_data, "furnace_efficiency")
+
+    # TODO: The documentation makes it look like the Units can be set to "Percent", but this throws an error when simulating
+    # Currently hardcoded to AFUE
+    is_steady_state = obj.get_val(type1_data, "Specifications,@isSteadyState")
+
+    furnace_sizing_factor = h2k.get_number_field(type1_data, "furnace_sizing_factor")
+    is_auto_sized = (
+        "Calculated" == obj.get_val(type1_data, "Specifications,OutputCapacity,English")
+        or furnace_capacity == 0
+    )
+
+    furnace_pilot_light = h2k.get_number_field(type1_data, "furnace_pilot_light")
+
+    furnace_fuel_type = h2k.get_selection_field(type1_data, "furnace_fuel_type")
+
+    # TODO: confirm desired behaviour around auto-sizing
+    furnace_dict = {
+        "SystemIdentifier": {"@id": model_data.get_system_id("primary_heating")},
+        "DistributionSystem": {"@idref": model_data.get_system_id("hvac_distribution")},
+        "HeatingSystemType": {
+            "Furnace": None
+        },  # potential to add pilot light info later
+        "HeatingSystemFuel": furnace_fuel_type,
+        **({} if is_auto_sized else {"HeatingCapacity": furnace_capacity}),
+        "AnnualHeatingEfficiency": {
+            "Units": (
+                "AFUE"  # "Percent" if is_steady_state == "true" else "AFUE"
+            ),  # "AFUE" / "Percent"
+            "Value": furnace_efficiency,
+        },
+        "FractionHeatLoadServed": 1,
+        **(
+            {"extension": {"HeatingAutosizingFactor": furnace_sizing_factor}}
+            if is_auto_sized
+            else {}
+        ),
+    }
+
+    # TODO: FractionHeatLoadServed is not allowed if this is a heat pump backup system
+    # Also must sum to 1 across all heating systems
+
+    # Add pilot light if present
+    if furnace_pilot_light > 0:
+        furnace_dict["HeatingSystemType"] = {
+            "Furnace": {
+                "PilotLight": "true",
+                "extension": {"PilotLightBtuh": furnace_pilot_light},
+            }
+        }
+
+    print("FURNACE: ", furnace_dict)
+
+    # No h2k representation for "gravity" distribution type
+    # Might need to update this based on logic around system types
+    model_data.set_hvac_distribution_type("air_regular velocity")
+
+    return furnace_dict

--- a/h2ktohpxml/systems/systems.py
+++ b/h2ktohpxml/systems/systems.py
@@ -40,8 +40,6 @@ def get_systems(h2k_dict, model_data):
     # This may be an empty dictionary, e.g. for baseboards, in which case it must not be included in hvac_dict
     hvac_distribution_result = get_hvac_distribution(h2k_dict, model_data)
 
-    print("DISTRIBUTION: ", hvac_distribution_result)
-
     hvac_dict = {
         "HVACPlant": {
             "PrimarySystems": {

--- a/h2ktohpxml/systems/systems.py
+++ b/h2ktohpxml/systems/systems.py
@@ -1,0 +1,60 @@
+# High level HPXML structure for HVAC portion:
+# {
+#     "HVACPlant": {
+#         "PrimarySystems": {
+#             "PrimaryHeatingSystem": {...},
+#             "PrimaryCoolingSystem": {...}
+#         },
+#         "HeatingSystem": {...},
+#         "CoolingSystem": {...},
+#     },
+#     "HVACControl": {...},
+#     "HVACDistribution": {...},
+# }
+# Certain sections must be conditionally present
+# For example, with electric baseboards, no HVACDistribution section should be present
+
+from .primary_heating import get_primary_heating_system
+from .hvac_control import get_hvac_control
+from .hvac_distribution import get_hvac_distribution
+
+
+# This function compiles translations for all HVAC and DHW sections, as there are many dependencies between these sections
+def get_systems(h2k_dict, model_data):
+
+    # Primary heating system as a component of the HVACPlant Section
+    primary_heating_result = get_primary_heating_system(h2k_dict, model_data)
+
+    # Primary cooling system as a component of the HVACPlant Section
+    # air_conditioner_result = get_air_conditioner(h2k_dict, model_data)
+    air_conditioner_result = {}
+
+    # Always produces a complete dictionary, includes set point information.
+    hvac_control_result = get_hvac_control(h2k_dict, model_data)
+
+    # This may be an empty dictionary, e.g. for baseboards, in which case it must not be included in hvac_dict
+    hvac_distribution_result = get_hvac_distribution(h2k_dict, model_data)
+
+    hvac_dict = {
+        "HVACPlant": {
+            "PrimarySystems": {
+                "PrimaryHeatingSystem": {
+                    "@idref": model_data.get_system_id("primary_heating")
+                }
+            },
+            "HeatingSystem": primary_heating_result,
+            **(
+                {"CoolingSystem": air_conditioner_result}
+                if air_conditioner_result != {}
+                else {}
+            ),
+        },
+        "HVACControl": hvac_control_result,
+        **(
+            {"HVACDistribution": hvac_distribution_result}
+            if hvac_distribution_result != {}
+            else {}
+        ),
+    }
+
+    return {"hvac_dict": hvac_dict, "dhw_dict": {}}

--- a/h2ktohpxml/systems/systems.py
+++ b/h2ktohpxml/systems/systems.py
@@ -40,6 +40,8 @@ def get_systems(h2k_dict, model_data):
     # This may be an empty dictionary, e.g. for baseboards, in which case it must not be included in hvac_dict
     hvac_distribution_result = get_hvac_distribution(h2k_dict, model_data)
 
+    print("DISTRIBUTION: ", hvac_distribution_result)
+
     hvac_dict = {
         "HVACPlant": {
             "PrimarySystems": {

--- a/h2ktohpxml/systems/systems.py
+++ b/h2ktohpxml/systems/systems.py
@@ -22,6 +22,11 @@ from .hvac_distribution import get_hvac_distribution
 # This function compiles translations for all HVAC and DHW sections, as there are many dependencies between these sections
 def get_systems(h2k_dict, model_data):
 
+    # Only one primary heating system, define its id
+    model_data.set_system_id({"primary_heating": "HeatingSystem1"})
+    model_data.set_system_id({"air_conditioner": "CoolingSystem1"})
+    model_data.set_system_id({"hvac_distribution": "HVACDistribution1"})
+
     # Primary heating system as a component of the HVACPlant Section
     primary_heating_result = get_primary_heating_system(h2k_dict, model_data)
 

--- a/h2ktohpxml/utils/units.py
+++ b/h2ktohpxml/utils/units.py
@@ -95,6 +95,28 @@ unit_map = {
         "L/s": {"cfm": {"scale": 2.118882, "offset": 0}},
         "cfm": {"L/s": {"scale": 0.471946998, "offset": 0}},
     },
+    "power": {
+        "BTU/h": {
+            "W": {"scale": 0.2930712104427134, "offset": 0.0},
+            "kW": {"scale": 0.0002930712104427134, "offset": 0.0},
+        },
+        "kW": {
+            "BTU/h": {"scale": 3412.14, "offset": 0.0},
+            "W": {"scale": 1000.0, "offset": 0.0},
+        },
+        "W": {
+            "BTU/h": {"scale": 3.41214, "offset": 0.0},
+            "kW": {"scale": 0.001, "offset": 0.0},
+        },
+    },
+    "fraction": {
+        "%": {"fraction": {"scale": 0.01, "offset": 0.0}},
+        "fraction": {"%": {"scale": 100.0, "offset": 0.0}},
+    },
+    "temperature": {
+        "F": {"C": {"scale": 0.5555555555555556, "offset": -17.77777777777778}},
+        "C": {"F": {"scale": 1.8, "offset": 32.0}},
+    },
 }
 
 

--- a/h2ktohpxml/utils/units.py
+++ b/h2ktohpxml/utils/units.py
@@ -117,6 +117,10 @@ unit_map = {
         "F": {"C": {"scale": 0.5555555555555556, "offset": -17.77777777777778}},
         "C": {"F": {"scale": 1.8, "offset": 32.0}},
     },
+    "daily_energy": {
+        "MJ/day": {"BTU/h": {"scale": 39.4924, "offset": 0}},
+        "BTU/h": {"MJ/day": {"scale": 0.025321328, "offset": 0}},
+    },
 }
 
 


### PR DESCRIPTION
Translating Baseboard, Furnace, and Boiler type 1 heating systems. Created logic to track the types of systems we have, as well as how to determine which type of heating distribution system is required (defaults/simplifications applied here for now until we get more info on assumptions in both engines). Also includes HVAC Control (essentially the temperature set point section from h2k). 

Combos left out until hot water is translated. All systems that are not supported will be bypassed, and the default HVAC system from the template will be used.

Translating the supported "Type1" (primary heating) systems produces valid HPXML files that will simulate.