### PR TITLE
Fixed error in attachment lookup

### DIFF
--- a/h2ktohpxml/config/selection.json
+++ b/h2ktohpxml/config/selection.json
@@ -88,7 +88,7 @@
             "Triplex (non-MURB)": "single-family attached",
             "Apartment (non-MURB)": "apartment unit",
             "Row house, end unit": "single-family attached",
-            "Mobile Home": "single-family attached",
+            "Mobile Home": "single-family detached",
             "Row house, middle unit": "single-family attached"
         },
         "murb_map": {


### PR DESCRIPTION
Mobile homes were incorrectly classified as attached

To address issue #26 