### PR TITLE
Update to windows.py:

### DIFF
--- a/h2ktohpxml/enclosure/windows.py
+++ b/h2ktohpxml/enclosure/windows.py
@@ -81,7 +81,7 @@ def get_windows(h2k_windows, parent_type, model_data):
                     if has_overhang
                     else {}
                 ),
-                "FractionOperable": "0",
+                "FractionOperable": "1",
                 "AttachedToWall": {"@idref": f"{parent_type}{parent_id}"},
                 "extension": {"H2kLabel": f"{window_label}"},
             }


### PR DESCRIPTION
 Makes FractionOperable equal to 1 (instead of 0) to allow for natural ventilation